### PR TITLE
Fix DI extension typo

### DIFF
--- a/src/Kdyby/Monolog/DI/MonologExtension.php
+++ b/src/Kdyby/Monolog/DI/MonologExtension.php
@@ -140,7 +140,7 @@ class MonologExtension extends CompilerExtension
 		}
 
 		if (empty(Debugger::$logDirectory)) {
-			$initialize->addBody('Tracy\Debugger::$logDirectory = ?', array($builder->expand('%logDir%')));
+			$initialize->addBody('Tracy\Debugger::$logDirectory = ?;', array($builder->expand('%logDir%')));
 		}
 	}
 


### PR DESCRIPTION
> PHP Parse error:  syntax error, unexpected '}' in nette/temp/cache/Nette.Configurator/d4f5ee73cd38ba081c5e86f66bea22ac.php on line 1361
