### PR TITLE
Extension: fixed builder parameters overwrite

### DIFF
--- a/src/Kdyby/Monolog/DI/MonologExtension.php
+++ b/src/Kdyby/Monolog/DI/MonologExtension.php
@@ -46,7 +46,12 @@ class MonologExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		$config = $this->getConfig($this->defaults);
-		$builder->parameters[$this->name] = array('name' => $config['name']);
+
+		if (array_key_exists($this->name, $builder->parameters)) {
+			$builder->parameters[$this->name]['name'] = $config['name'];
+		} else {
+			$builder->parameters[$this->name] = array('name' => $config['name']);
+		}
 
 		$builder->addDefinition($this->prefix('logger'))
 			->setClass('Kdyby\Monolog\Logger', array($config['name']));

--- a/tests/KdybyTests/Monolog/Extension.phpt
+++ b/tests/KdybyTests/Monolog/Extension.phpt
@@ -53,6 +53,16 @@ class ExtensionTest extends Tester\TestCase
 
 
 
+	public function testParameters()
+	{
+		$parameters = $this->createContainer()->getParameters();
+		Assert::true(array_key_exists('monolog', $parameters));
+		Assert::true(array_key_exists('name', $parameters['monolog']));
+		Assert::true(array_key_exists('syslog', $parameters['monolog']));
+	}
+
+
+
 	public function testFunctional()
 	{
 		foreach (array_merge(glob(TEMP_DIR . '/*.log'), glob(TEMP_DIR . '/*.html')) as $logFile) {

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -6,6 +6,11 @@ common:
 		cacheStorage:
 			class: Nette\Caching\Storages\MemoryStorage
 
+	parameters:
+		monolog:
+			syslog:
+				level: Monolog\Logger::DEBUG
+
 v22 < common:
 	nette:
 		security:


### PR DESCRIPTION
As of now, section `monolog` in `parameters` section in Nette configuration gets overwritten by MonologExtension.

This pull request fixes the issue and adds tests.
No documentation changes needed.