### PR TITLE
Tracy output processor

### DIFF
--- a/src/Kdyby/Monolog/Diagnostics/TracyLogger.php
+++ b/src/Kdyby/Monolog/Diagnostics/TracyLogger.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kdyby\Monolog\Diagnostics;
+
+use Tracy\Logger;
+
+class TracyLogger extends Logger
+{
+
+	/**
+	 * @return string
+	 */
+	public function logException($exception, $file = NULL)
+	{
+		return parent::logException($exception, $file);
+	}
+
+}

--- a/src/Kdyby/Monolog/Diagnostics/TracyLoggerOld.php
+++ b/src/Kdyby/Monolog/Diagnostics/TracyLoggerOld.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Kdyby\Monolog\Diagnostics;
+
+use Tracy\Logger;
+
+class TracyLoggerOld extends Logger
+{
+
+	/**
+	 * @return string
+	 */
+	public function getExceptionFile(\Exception $exception)
+	{
+		return parent::getExceptionFile($exception);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function logException(\Exception $exception, $file = NULL)
+	{
+		return parent::logException($exception, $file);
+	}
+
+}

--- a/src/Kdyby/Monolog/Processor/TracyExceptionProcessor.php
+++ b/src/Kdyby/Monolog/Processor/TracyExceptionProcessor.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kdyby\Monolog\Processor;
+
+use Kdyby\Monolog\Diagnostics\MonologAdapter;
+use Kdyby\Monolog\Diagnostics\TracyLogger;
+use Kdyby\Monolog\Diagnostics\TracyLoggerOld;
+use Tracy\Debugger;
+
+class TracyExceptionProcessor
+{
+
+	private $processedExceptionFileNames = [];
+
+	/**
+	 * @var \Kdyby\Monolog\Diagnostics\TracyLogger
+	 */
+	private $tracyLogger;
+
+	/**
+	 * @var string
+	 */
+	private $baseUrl;
+
+	public function __construct($tracyDir, $baseUrl)
+	{
+		$this->baseUrl = rtrim($baseUrl, '/');
+
+		if (version_compare(Debugger::VERSION, '2.3.3', '>=')) {
+			$this->tracyLogger = new TracyLogger($tracyDir);
+		} else {
+			$this->tracyLogger = new TracyLoggerOld($tracyDir);
+		}
+	}
+
+	public function __invoke(array $record)
+	{
+		if (!isset($record['context']['tracy']) && isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+			$fileName = $this->tracyLogger->getExceptionFile($record['context']['exception']);
+
+			if (!isset($this->processedExceptionFileNames[$fileName])) {
+				$this->tracyLogger->logException($record['context']['exception'], $fileName);
+				$this->processedExceptionFileNames[$fileName] = TRUE;
+			}
+
+			$record['context']['tracy'] = ltrim(strrchr($fileName, DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR);
+		}
+
+		if (isset($record['context']['tracy'])) {
+			$record['context']['tracyUrl'] = sprintf('%s/%s', $this->baseUrl, $record['context']['tracy']);
+		}
+
+		return $record;
+	}
+
+}


### PR DESCRIPTION
He're a simple patch that will make Monolog render Tracy exceptions and pass exception file URLs into Monolog messages. I have simplified it compared to #6 by removing the handler that actually rendered exceptions and moving all the code to the processor. It's easier however it can render Tracy files without logging the corresponding messages (there's not much we can do about it, unfortunately).

The processor needs to know the path where Tracy files are placed and a base URL where they are available. It works when Monolog si called both directly or indirectly

* When calling Tracy directly (and Monolog indirectly via the MonologAdapter), there is a ```tracy``` field in the message context. In that case it just takes the exception file name and creates an URL where it's available.
* When calling Monolog directly, you can place an exception into message context ```exception``` field. When the processor finds this field, it renders the exception and creates its URL.

There are drawbacks however

* Considering how Monolog handlers work, I believe that in the latter case the exception will be rendered for every handler, possibly multiple times. This could be solved quite easily in case it would be a problem.
* In order to generate exception files, the processor needs to call the ```logException``` method that is protected in Tracy logger. That's why it needs the ```TracyLogger``` class.
* Tracy changed the Logger interface somewhere between 2.3.2 and master removing the Exception typehint. That's why there would be two helper-logger classes required to be forward-compatible.

Anyway, this is just a POC, I'll look into the exceptions-are-generated-for-every-handler-present issue and possibly into the compatibilty issue, too. However quite frankly I have no idea about such changes in Tracy development so it's quite likely that I will overlook something.