### PR TITLE
Added configuration property which allows disabling priority processor

### DIFF
--- a/src/Kdyby/Monolog/DI/MonologExtension.php
+++ b/src/Kdyby/Monolog/DI/MonologExtension.php
@@ -39,6 +39,7 @@ class MonologExtension extends CompilerExtension
 		'name' => 'app',
 		'hookToTracy' => TRUE,
 		'tracyBaseUrl' => NULL,
+		'usePriorityProcessor' => TRUE,
 		// 'registerFallback' => TRUE,
 	);
 
@@ -119,11 +120,13 @@ class MonologExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 
-		// change channel name to priority if available
-		$builder->addDefinition($this->prefix('processor.priorityProcessor'))
-			->setClass('Kdyby\Monolog\Processor\PriorityProcessor')
-			->addTag(self::TAG_PROCESSOR)
-			->addTag(self::TAG_PRIORITY, 20);
+		if ($config['usePriorityProcessor'] === TRUE) {
+			// change channel name to priority if available
+			$builder->addDefinition($this->prefix('processor.priorityProcessor'))
+				->setClass('Kdyby\Monolog\Processor\PriorityProcessor')
+				->addTag(self::TAG_PROCESSOR)
+				->addTag(self::TAG_PRIORITY, 20);
+		}
 
 		$builder->addDefinition($this->prefix('processor.tracyException'))
 			->setClass('Kdyby\Monolog\Processor\TracyExceptionProcessor', [$builder->expand('%logDir%')])


### PR DESCRIPTION
The only current solution is to write some dummy priority processor and rewrite its definition in custom `config.neon` which is too complicated.