### PR TITLE
Adds possibility to override MonologAdapter in config

### DIFF
--- a/src/Kdyby/Monolog/DI/MonologExtension.php
+++ b/src/Kdyby/Monolog/DI/MonologExtension.php
@@ -40,6 +40,7 @@ class MonologExtension extends CompilerExtension
 		'hookToTracy' => TRUE,
 		'tracyBaseUrl' => NULL,
 		'usePriorityProcessor' => TRUE,
+		'adapter' => 'Kdyby\Monolog\Diagnostics\MonologAdapter',
 		// 'registerFallback' => TRUE,
 	];
 
@@ -75,7 +76,7 @@ class MonologExtension extends CompilerExtension
 
 		// Tracy adapter
 		$builder->addDefinition($this->prefix('adapter'))
-			->setClass('Kdyby\Monolog\Diagnostics\MonologAdapter', [$this->prefix('@logger')])
+			->setClass($config['adapter'], [$this->prefix('@logger')])
 			->addTag('logger');
 
 		if ($builder->hasDefinition('tracy.logger')) { // since Nette 2.3

--- a/src/Kdyby/Monolog/Diagnostics/MonologAdapter.php
+++ b/src/Kdyby/Monolog/Diagnostics/MonologAdapter.php
@@ -29,7 +29,7 @@ class MonologAdapter extends Logger
 	/**
 	 * @var array
 	 */
-	private $priorityMap = [
+	protected $priorityMap = [
 		self::DEBUG => Monolog\Logger::DEBUG,
 		self::INFO => Monolog\Logger::INFO,
 		self::WARNING => Monolog\Logger::WARNING,
@@ -41,7 +41,7 @@ class MonologAdapter extends Logger
 	/**
 	 * @var Monolog\Logger
 	 */
-	private $monolog;
+	protected $monolog;
 
 
 


### PR DESCRIPTION
You can now specify your own Adapter in the config.neon, in which you can for example opt out from having exceptions saved to a file or add more context to your error messages (such as current Request etc.)
