### PR TITLE
Add configuration option for setting "access" priority

### DIFF
--- a/src/DI/MonologExtension.php
+++ b/src/DI/MonologExtension.php
@@ -25,6 +25,7 @@ use Nette\PhpGenerator\ClassType as ClassTypeGenerator;
 use Nette\PhpGenerator\PhpLiteral;
 use Psr\Log\LoggerAwareInterface;
 use Tracy\Debugger;
+use Tracy\ILogger;
 
 /**
  * Integrates the Monolog seamlessly into your Nette Framework application.
@@ -49,6 +50,7 @@ class MonologExtension extends \Nette\DI\CompilerExtension
 		'tracyBaseUrl' => NULL,
 		'usePriorityProcessor' => TRUE,
 		// 'registerFallback' => TRUE,
+		'accessPriority' => ILogger::INFO,
 	];
 
 	public function loadConfiguration()
@@ -77,6 +79,7 @@ class MonologExtension extends \Nette\DI\CompilerExtension
 				'monolog' => $this->prefix('@logger'),
 				'blueScreenRenderer' => $this->prefix('@blueScreenRenderer'),
 				'email' => Debugger::$email,
+				'accessPriority' => $config['accessPriority'],
 			])
 			->addTag('logger');
 

--- a/src/Tracy/MonologAdapter.php
+++ b/src/Tracy/MonologAdapter.php
@@ -46,15 +46,22 @@ class MonologAdapter extends \Tracy\Logger
 	 */
 	private $blueScreenRenderer;
 
+	/**
+	 * @var int
+	 */
+	private $accessPriority;
+
 	public function __construct(
 		MonologLogger $monolog,
 		BlueScreenRenderer $blueScreenRenderer,
-		$email = NULL
+		$email = NULL,
+		$accessPriority = self::INFO
 	)
 	{
 		parent::__construct($blueScreenRenderer->directory, $email);
 		$this->monolog = $monolog;
 		$this->blueScreenRenderer = $blueScreenRenderer;
+		$this->accessPriority = $accessPriority;
 	}
 
 	/**
@@ -90,18 +97,15 @@ class MonologAdapter extends \Tracy\Logger
 			]));
 		}
 
-		switch ($priority) {
-			case self::ACCESS:
-				$this->monolog->addInfo($message, $context);
-				break;
-
-			default:
-				$this->monolog->addRecord(
-					$this->getLevel($priority),
-					$message,
-					$context
-				);
+		if ($priority === self::ACCESS) {
+			$priority = $this->accessPriority;
 		}
+
+		$this->monolog->addRecord(
+			$this->getLevel($priority),
+			$message,
+			$context
+		);
 
 		return $exceptionFile;
 	}


### PR DESCRIPTION
With this PR you can set custom priority (level, severity) to "access" messages generated when trying to access non-existent page (404):

```
monolog:
	accessPriority: debug
```